### PR TITLE
Docker wrong PID + Reduce Size of Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,16 @@ RUN apt-get update && \
          libevent-dev \
          bsdmainutils \
          vim \
-         software-properties-common
+         software-properties-common && \
+         rm -rf /var/lib/apt/lists/* && apt-get clean
 
 RUN add-apt-repository ppa:bitcoin/bitcoin && \
     apt-get update && \
     apt-get --no-install-recommends --yes install \
           libdb4.8-dev \
           libdb4.8++-dev \
-          libminiupnpc-dev 
+          libminiupnpc-dev && \
+          rm -rf /var/lib/apt/lists/* && apt-get clean
 
 WORKDIR /ips
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ VOLUME ["/root/.ips"]
 
 EXPOSE 22331
 
-CMD /ips/src/ipsd && tail -f /root/.ips/debug.log
+CMD exec /ips/src/ipsd && tail -f /root/.ips/debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,13 @@ RUN ./autogen.sh && \
     ./configure && \
     make && \
     strip src/ipsd && \
-    strip src/ips-cli
+    strip src/ips-cli && \
+    mv src/ipsd /usr/local/bin/ && \
+    mv src/ips-cli /usr/local/bin/ && \
+    rm -rf /ips 
 
 VOLUME ["/root/.ips"]
 
 EXPOSE 22331
 
-CMD exec /ips/src/ipsd && tail -f /root/.ips/debug.log
+CMD exec ipsd && tail -f /root/.ips/debug.log


### PR DESCRIPTION
ipsd is running as pid 5 docker sends on a stop command a sigterm only to pid 1 this is why we have to stop ipsd manual or the wallet will get corrupted.

Before:
![image](https://user-images.githubusercontent.com/5182697/41825941-93d09c5e-77f3-11e8-8ae6-79f634975836.png)

After:
![image](https://user-images.githubusercontent.com/5182697/41825947-a7e3ee3a-77f3-11e8-98f8-e921ad72841e.png)

![image](https://user-images.githubusercontent.com/5182697/41825990-209c76d0-77f4-11e8-8659-2e3cdea8881c.png)


I stopped the Container just with Docker stop and it works without having to stop ipsd before.